### PR TITLE
Fix pnpm lockfile to remove OpenRouter provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@mastra/memory':
         specifier: latest
         version: 0.14.2(@mastra/core@0.15.2(openapi-types@12.1.3)(react@19.1.1)(zod@3.25.76))(react@19.1.1)(zod@3.25.76)
-      '@openrouter/ai-sdk-provider':
-        specifier: ^1.2.0
-        version: 1.2.0(ai@4.3.19(react@19.1.1)(zod@3.25.76))(zod@3.25.76)
       ai:
         specifier: ^4.3.17
         version: 4.3.19(react@19.1.1)(zod@3.25.76)
@@ -579,13 +576,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@openrouter/ai-sdk-provider@1.2.0':
-    resolution: {integrity: sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ai: ^5.0.0
-      zod: ^3.24.1 || ^v4
 
   '@opentelemetry/api-logs@0.203.0':
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
@@ -3515,11 +3505,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
-
-  '@openrouter/ai-sdk-provider@1.2.0(ai@4.3.19(react@19.1.1)(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      ai: 4.3.19(react@19.1.1)(zod@3.25.76)
-      zod: 3.25.76
 
   '@opentelemetry/api-logs@0.203.0':
     dependencies:


### PR DESCRIPTION
## Summary
- update `pnpm-lock.yaml` to remove the stale `@openrouter/ai-sdk-provider` dependency entry so the lockfile matches the current package.json

## Testing
- POSTHOG_DISABLED=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce5b9f24d88320958634d52d6908ac