### PR TITLE
Use Responses API for Mister agent

### DIFF
--- a/src/mastra/agents/mister.ts
+++ b/src/mastra/agents/mister.ts
@@ -87,7 +87,8 @@ Output:
 • If a tool fails, say what happened and suggest the next step.
 `,
   
-  model: openai('gpt-4.1-mini'),
+  // gpt-4.1 models require the OpenAI Responses API
+  model: openai.responses('gpt-4.1-mini'),
   
   tools: {
     // DB + token tools


### PR DESCRIPTION
## Summary
- switch the Mister agent to call the OpenAI Responses API when using `gpt-4.1-mini`
- add an inline note explaining the requirement for gpt-4.1 models

## Testing
- `pnpm build` *(fails: Mastra CLI repeatedly attempts to send PostHog telemetry and the network call is unreachable in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68ce62ae077c832086a3f2af146e864a